### PR TITLE
Changed  views.py to Disallow any Teacher Signup without @teachers.edu

### DIFF
--- a/classmanager/classroom/views.py
+++ b/classmanager/classroom/views.py
@@ -32,6 +32,12 @@ def TeacherSignUp(request):
     registered = False
 
     if request.method == "POST":
+        #print("*****************")
+        emailxxx = request.POST.get('email')
+        if not str(emailxxx).endswith("@teachers.edu"):
+            #print("Does not end with @teachers.edu")
+            return HttpResponseRedirect(reverse("classroom:TeacherSignUp"))
+        #print("*****************")
         user_form = UserForm(data = request.POST)
         teacher_profile_form = TeacherProfileForm(data = request.POST)
 


### PR DESCRIPTION
Hi,
I have added a few lines to disallow teacher sign up without @teachers.edu domain.

All new teachers must sign up using @teachers.edu email address.

Examples of valid addresses:

abc@teachers.edu
foobar@teachers.edu
alice@teachers.edu

Kindly allow the pull and merge codes.

Thanks,
Syed Fasih Uddin
https://www.linkedin.com/in/sssfasih/